### PR TITLE
fix(backend+cachebuster): JSONP for GET + robust approved filter + CSS/JS cache-bust

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Kommentarer</title>
-  styles.css
+  styles.css?v=2025-10-04-1
   <meta name="color-scheme" content="light dark" />
 </head>
 <body>
@@ -73,6 +73,6 @@
   <!-- Toast för kvittenser -->
   <div id="toast" class="toast" role="status" aria-live="assertive" aria-atomic="true"></div>
 
-  app.js</script>
+  app.js?v=2025-10-04-1</script>
 </body>
 </html>


### PR DESCRIPTION
Denna PR åtgärdar:
- **Backend (Code.gs)**:
  - `json_(obj, callback)` → JSONP om `callback` finns, annars JSON
  - `doGet(e)` → för list, vidarebefordra callback
  - `handleList_(p, cb)` → robust header-hantering + tydligt filter (endast approved i publikt flöde)
- **Frontend**:
  - `index.html`: cache-buster (`?v=2025-10-04-1`) på `styles.css` och `app.js` för att undvika gammal cache

**Efter merge – att göra:**
1) Apps Script → `Manage deployments` → **Edit** Web App (eller New deployment)  
   - *Who has access*: `Anyone with the link` (om externa ska kunna posta)
2) Testa:
   - GET JSONP: `/exec?action=list&limit=1&callback=cb` → ska returnera `cb({...})`
   - Publik vy (GitHub Pages): lista laddas, styling uppdaterad
   - Skicka kommentar: pending‑ruta (inte synlig i publika listan förrän approved)
   - Admin pendings: `/#admin` → logga in → **Pendings** visas → `Godkänn` fungerar (POST)
